### PR TITLE
Fix each in deciders

### DIFF
--- a/network/combinators.js
+++ b/network/combinators.js
@@ -328,7 +328,7 @@ network.combinators = (function(){
       let sum = 0;
       for (const k of Object.keys(input)) {
         const condition = this.compare_(input, k, this.right);
-        if (!condition) { break; }
+        if (!condition) { continue; }
         sum += this.asOne ? 1 : input[k];
       }
       const r = {};
@@ -349,7 +349,7 @@ network.combinators = (function(){
       const r = {};
       for (const k of Object.keys(input)) {
         const condition = this.compare_(input, k, this.right);
-        if (!condition) { break; }
+        if (!condition) { continue; }
         r[k] = this.asOne ? 1 : input[k];
       }
       return r;

--- a/test/simulation_tests.js
+++ b/test/simulation_tests.js
@@ -30,7 +30,7 @@
     
   const testSingleCombinator = function(combinator, expectedOutputSignals) {
     simulateAndAssertTests(
-        'Main(){ {a:4,b:13,c:612} -> IN IN -> ' + combinator + ' -> OUT }', 2,
+        'Main(){ {b:13,a:4,c:612} -> IN IN -> ' + combinator + ' -> OUT }', 2,
         { 'IN': { 'a': 4, 'b': 13, 'c': 612 },
           'OUT': expectedOutputSignals });
   }
@@ -141,21 +141,3 @@
     }`,
     1, { 'OMEGA': {'x': 42} });
 })();
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests.html
+++ b/tests.html
@@ -4,6 +4,7 @@
     <script type="text/javascript" src="utils.js"></script>
     <script type="text/javascript" src="network/base.js"></script>
     <script type="text/javascript" src="network/combinators.js"></script>
+    <script type="text/javascript" src="network/segmenting.js"></script>
     <script type="text/javascript" src="parser.js"></script>
     <script type="text/javascript" src="code.js"></script>
     
@@ -22,19 +23,3 @@
   </body>
   <script type="text/javascript">testUtils.runAllTests();</script>
 </html>
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
-    


### PR DESCRIPTION
This example from tests currently works:

```
Main() {
  {a:4,b:13,c:612} -> IN
  IN -> each > 10 then each -> OUT
}
```

but this doesn't:

```
Main() {
  {b:13,a:4,c:612} -> IN
  IN -> each > 10 then each -> OUT
}
```

Even though order of signals should never matter ever. The reason is: `break` where `continue` should be.

Also included `network/segmenting.js` to tests.html, 'cause they all fail without it.